### PR TITLE
Fixed spelling errors on homepage

### DIFF
--- a/app/hyperloop/components/pages/home/home_page.rb
+++ b/app/hyperloop/components/pages/home/home_page.rb
@@ -67,7 +67,7 @@ class HomePage < Hyperloop::Router::Component
     DIV(class: 'ui page grid') do
       DIV(class: 'fifteen wide column centered') do
         Sem.Header(size: :huge, textAlign: :center) do
-          DIV {"Hyperstack integrates with your favourage back-end to sunchronize data between any ActiveRecord based ORM and the front-end."}
+          DIV {"Hyperstack integrates with your favorite back-end to synchronize data between any ActiveRecord based ORM and the front-end."}
           BR()
           DIV {"We even include a fast, hot-loading build environment for pure programmer joy!"}
         end


### PR DESCRIPTION
Fixed spelling errors on homepage:
favourage -> favorite
sunchronize -> synchronize