### PR TITLE
Update code example, keep input text after hiding

### DIFF
--- a/app/hyperstack/components/home/code_examples.rb
+++ b/app/hyperstack/components/home/code_examples.rb
@@ -76,7 +76,7 @@ class UsingState < HyperComponent
 
   def input
     DIV(class: 'ui input fluid block') do
-      INPUT(type: :text).on(:change) do |evt|
+      INPUT(type: :text, value: @input_value).on(:change) do |evt|
         # we are updating the value per keypress
         # using mutate will cause a rerender
         mutate @input_value = evt.target.value


### PR DESCRIPTION
In the `Stateful Components` section:

If you type in the input, click the button to hide then click it again to show, the text shows up below the input but the input box itself is empty.  This change keeps the value in the input even after hiding.